### PR TITLE
Service Worker and Appcache

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "karma-webpack": "1.7.0",
     "node-sass": "^3.4.2",
     "null-loader": "0.1.1",
+    "offline-plugin": "^3.3.0",
     "phantomjs-prebuilt": "^2.1.4",
     "postcss-loader": "^0.9.1",
     "protractor": "^3.1.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ const ENV_PROVIDERS = [];
 // depending on the env mode, enable prod mode or add debugging modules
 if (process.env.ENV === 'build') {
   enableProdMode();
+  require('offline-plugin/runtime').install();
 } else {
   ENV_PROVIDERS.push(ELEMENT_PROBE_PROVIDERS);
 }

--- a/src/public/service-worker.js
+++ b/src/public/service-worker.js
@@ -1,1 +1,0 @@
-// This file is intentionally without code.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ var autoprefixer = require('autoprefixer');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
+var OfflinePlugin = require('offline-plugin');
 
 /**
  * Env
@@ -217,7 +218,11 @@ module.exports = function makeWebpackConfig() {
       // Reference: https://github.com/kevlened/copy-webpack-plugin
       new CopyWebpackPlugin([{
         from: root('src/public')
-      }])
+      }]),
+
+      new OfflinePlugin({
+        excludes: ['**/*.ts', '**/*.map']
+      })
     );
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -220,6 +220,8 @@ module.exports = function makeWebpackConfig() {
         from: root('src/public')
       }]),
 
+      // Reference: https://github.com/NekR/offline-plugin
+      // Register all output assets to serviceworkers and appcache, except those specified in excludes
       new OfflinePlugin({
         excludes: ['**/*.ts', '**/*.map']
       })


### PR DESCRIPTION
This PR adds the webpack plugin: [offline-plugin](https://github.com/NekR/offline-plugin)

This plugins runs in `build` mode, so looks for all output assets generated except: `**/*.ts & **/*.map`.

All assets that match will be included in both configs, serviceworker and appcache.

**Testing**

Run: `npm run build`

In `dist` folder will be generated `appcache` folder which register all output assets and a `sw.js` file which also register all outputs, with their respective hashes automatically.

Access `localhost:8080/#/` once, then shut down the server and access again, close the browser and etc... you'll see that website works fine.

In chrome dev tools, on tab `Resources` in Cache Storage is all assets available offline.

Hope it helps guys!

[]'s
Natan Deitch
