### PR TITLE
Replace deprecated isparta-loader with istanbul-instrumenter-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.7.1",
-    "isparta-loader": "^2.0.0",
+    "istanbul-instrumenter-loader": "^1.0.0",
     "jasmine-core": "^2.3.4",
     "karma": "^1.1.0",
     "karma-coverage": "^1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,7 +130,10 @@ module.exports = function makeWebpackConfig () {
         /node_modules/,
         /\.spec\.js$/
       ],
-      loader: 'isparta-loader'
+      loader: 'istanbul-instrumenter',
+      query: {
+        esModules: true
+      }
     })
   }
 


### PR DESCRIPTION
This removes the deprecated library as outlined in: https://github.com/preboot/angular-webpack/issues/51

It uses a different module than the one specified in the issue above, but it does not require more dependencies than itself.
