### PR TITLE
fix 'npm run watch' docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ It will start a local server using `webpack-dev-server` which will watch, build 
 ### Build files
 
 * single run: `npm run build`
-* build files and watch: `npm run watch`
+* build files and watch: `npm run server`
 
 ## Testing
 


### PR DESCRIPTION
The command ```npm run watch``` no longer exists. It's now ```npm run server```. This PR fixes the README.