### PR TITLE
pin zone.js to 0.8.12 until 0.8.13 is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "reflect-metadata": "^0.1.3",
     "tslib": "^1.7.1",
     "rxjs": "^5.0.1",
-    "zone.js": "^0.8.10"
+    "zone.js": "0.8.12"
   },
   "devDependencies": {
     "@angularclass/hmr": "^1.0.1",


### PR DESCRIPTION
There is a bug angular/zone.js#832 that caused this not to run when dependencies when updated(51c72e481eecdaa461b8c3a1f021d2f2064e4b80). Confirmed fixed version (not ^) 0.8.12 resolved the problem.