### PR TITLE
Source maps slows down test-watch too much, so just keep source maps …

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,9 @@ module.exports = function makeWebpackConfig() {
     config.devtool = 'source-map';
   }
   else if (isTest) {
-    config.devtool = 'inline-source-map';
+    if(!isTestWatch) { // source maps slows down test-watch too much, so just keep source maps for 'single run' test
+      config.devtool = 'inline-source-map';
+    }
   }
   else {
     config.devtool = 'eval-source-map';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,6 +149,7 @@ module.exports = function makeWebpackConfig() {
     config.module.rules.push({
       test: /\.ts$/,
       enforce: 'pre',
+      include: path.resolve('src'),
       loader: 'tslint-loader'
     });
   }


### PR DESCRIPTION
Source maps slows down test-watch too much, so removed source maps unless doing a 'single run' test.